### PR TITLE
add validation for PATs only

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -12,6 +12,7 @@ import (
 func GetFlagOrEnv(cmd *cobra.Command, flags map[string]bool) map[string]string {
 	values := make(map[string]string)
 	var missing []string
+	var isTokenValid bool
 
 	for name, required := range flags {
 		// For CLI flags, strip GHMPKG_ prefix if present
@@ -43,10 +44,20 @@ func GetFlagOrEnv(cmd *cobra.Command, flags map[string]bool) map[string]string {
 		} else if required {
 			missing = append(missing, flagName)
 		}
+
+		//if flagname contains `-token` or envName container `TOKEN`check if token is valid
+		if strings.Contains(flagName, "token") || strings.Contains(envName, "TOKEN") {
+			isTokenValid = checkToken(value)
+		}
 	}
 
 	if len(missing) > 0 {
 		fmt.Fprintf(os.Stderr, "Error: missing required values: %s\n", strings.Join(missing, ", "))
+		os.Exit(1)
+	}
+
+	if !isTokenValid {
+		fmt.Println("Error: token must be a GitHub Personal Access Token.")
 		os.Exit(1)
 	}
 
@@ -71,7 +82,7 @@ func ShowConnectionStatus(actionType string) {
 
 func getNormalizedEndpoint(key string) string {
 	hostname := viper.GetString(key)
-	if hostname != ""  {
+	if hostname != "" {
 		hostname = strings.TrimPrefix(hostname, "http://")
 		hostname = strings.TrimPrefix(hostname, "https://")
 		hostname = strings.TrimSuffix(hostname, "/api/v3")
@@ -95,4 +106,8 @@ func getProxyStatus() string {
 		return "✅ Proxy: Configured\n"
 	}
 	return "❎ Proxy: Not configured\n"
+}
+
+func checkToken(token string) bool {
+	return strings.HasPrefix(token, "ghp_") || strings.HasPrefix(token, "github_pat_")
 }


### PR DESCRIPTION
This pull request introduces a new validation mechanism for GitHub tokens in the `cmd/common.go` file. The main changes include adding a new boolean variable to track token validity, implementing a check for token validity within the `GetFlagOrEnv` function, and defining a new helper function to validate the token format.
Token validation feature:

* Added a new boolean variable `isTokenValid` to track the validity of tokens in the `GetFlagOrEnv` function.
* Implemented a check within the `GetFlagOrEnv` function to validate tokens if the flag name contains `-token` or the environment variable name contains `TOKEN`.
* Added a new function `checkToken` to encapsulate the logic for validating tokens, ensuring they start with `ghp_` or `github_pat_`.