### PR TITLE
Add migration path and repository filtering options to sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,40 @@ Usage:
 
 Flags:
   -h, --help                         help for sync
-  -u, --target-hostname string       GitHub Enterprise source hostname url (optional)
-  -t, --target-organization string   Target Organization to sync releases from
-  -b, --target-token string          Target Organization GitHub token. Scopes: admin:org
+  -o, --source-organization string   Source Organization name (required)
+  -p, --target-organization string   Target Organization to sync packages to (required)
+  -t, --target-token string          Target Organization GitHub token. Scopes: admin:org (required)
+  -m, --migration-path string        Path to the migration directory (default: ./migration-packages)
+  -r, --repository string            Repository to sync (optional, syncs all repositories if not specified)
 ```
+
+### Example Sync Command for all packages
 
 ```bash
 gh migrate-packages sync \
+  --source-organization mona-actions \
   --target-organization mona-emu \
   --target-token ghp_xxxxxxxxxxxx
+```
+
+### Example Sync Command with custom migration path
+
+```bash
+gh migrate-packages sync \
+  --source-organization mona-actions \
+  --target-organization mona-emu \
+  --target-token ghp_xxxxxxxxxxxx \
+  --migration-path /path/to/custom/migration/directory
+```
+
+### Example Sync Command for specific repository
+
+```bash
+gh migrate-packages sync \
+  --source-organization mona-actions \
+  --target-organization mona-emu \
+  --target-token ghp_xxxxxxxxxxxx \
+  --repository my-specific-repo
 ```
 
 ### Sync summary
@@ -315,6 +340,8 @@ GHMPKG_TARGET_HOSTNAME=                  # Target hostname
 GHMPKG_TARGET_TOKEN=ghp_yyy              # Target token
 GHMPKG_PACKAGE_TYPE=npm                  # Package types to export (all, docker, rubygem, maven, npm, nuget)
 GHMPKG_PACKAGE_TYPE=docker
+GHMPKG_MIGRATION_PATH=./my-migration     # Custom migration directory path (default: ./migration-packages)
+GHMPKG_REPOSITORY=my-specific-repo       # Specific repository to sync (optional)
 ```
 
 2. Run the commands without flags - the tool will automatically load values from the .env file:

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -33,9 +33,13 @@ func init() {
 	syncCmd.Flags().StringP("source-organization", "o", "", "Organization (required)")
 	syncCmd.Flags().StringP("target-organization", "p", "", "Organization (required)")
 	syncCmd.Flags().StringP("target-token", "t", "", "GitHub token (required)")
+	syncCmd.Flags().StringP("migration-path", "m", "./migration-packages", "Path to the migration directory (default: ./migration-packages)")
+	syncCmd.Flags().StringP("repository", "r", "", "Repository to sync (optional, syncs all repositories if not specified)")
 
 	//viper.BindPFlag("GHMPKG_TARGET_HOSTNAME", syncCmd.Flags().Lookup("target-hostname"))
 	viper.BindPFlag("GHMPKG_SOURCE_ORGANIZATION", syncCmd.Flags().Lookup("source-organization"))
 	viper.BindPFlag("GHMPKG_TARGET_ORGANIZATION", syncCmd.Flags().Lookup("target-organization"))
 	viper.BindPFlag("GHMPKG_TARGET_TOKEN", syncCmd.Flags().Lookup("target-token"))
+	viper.BindPFlag("GHMPKG_MIGRATION_PATH", syncCmd.Flags().Lookup("migration-path"))
+	viper.BindPFlag("GHMPKG_REPOSITORY", syncCmd.Flags().Lookup("repository"))
 }

--- a/internal/providers/common.go
+++ b/internal/providers/common.go
@@ -171,7 +171,11 @@ func (p *BaseProvider) downloadPackage(
 	if downloadedFilename == nil {
 		downloadedFilename = &filename
 	}
-	outputPath := filepath.Join("migration-packages", "packages", owner, packageType, packageName, version, *downloadedFilename)
+	migrationPath := viper.GetString("GHMPKG_MIGRATION_PATH")
+	if migrationPath == "" {
+		migrationPath = "./migration-packages"
+	}
+	outputPath := filepath.Join(migrationPath, "packages", owner, packageType, packageName, version, *downloadedFilename)
 
 	if utils.FileExists(outputPath) {
 		logger.Warn("File already exists", zap.String("outputPath", outputPath))
@@ -219,13 +223,17 @@ func (p *BaseProvider) uploadPackage(
 	getUrl func() (string, error),
 	upload func(string, string) (ResultState, error),
 ) (ResultState, error) {
+migrationPath := viper.GetString("GHMPKG_MIGRATION_PATH")
+	if migrationPath == "" {
+		migrationPath = "./migration-packages"
+	}
 	var packageDir string
 	if packageType == "container" {
 		parts := strings.Split(filename, ":")
 		tag := parts[1]
-		packageDir = filepath.Join("migration-packages", "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, tag)
+		packageDir = filepath.Join(migrationPath, "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, tag)
 	} else {
-		packageDir = filepath.Join("migration-packages", "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, version)
+		packageDir = filepath.Join(migrationPath, "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, version)
 	}
 
 	if !utils.FileExists(packageDir) {

--- a/internal/providers/common.go
+++ b/internal/providers/common.go
@@ -223,7 +223,7 @@ func (p *BaseProvider) uploadPackage(
 	getUrl func() (string, error),
 	upload func(string, string) (ResultState, error),
 ) (ResultState, error) {
-migrationPath := viper.GetString("GHMPKG_MIGRATION_PATH")
+	migrationPath := viper.GetString("GHMPKG_MIGRATION_PATH")
 	if migrationPath == "" {
 		migrationPath = "./migration-packages"
 	}

--- a/internal/providers/container.go
+++ b/internal/providers/container.go
@@ -88,10 +88,6 @@ func (p *ContainerProvider) Connect(logger *zap.Logger) error {
 	sourceOrg := viper.GetString("GHMPKG_SOURCE_ORGANIZATION")
 	sourceToken := viper.GetString("GHMPKG_SOURCE_TOKEN")
 
-	if sourceOrg == "" || sourceToken == "" {
-		return fmt.Errorf("missing required environment variables: GHMPKG_SOURCE_ORGANIZATION and/or GHMPKG_SOURCE_TOKEN")
-	}
-
 	ctx := context.Background()
 
 	// Create Docker client

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -125,6 +125,16 @@ func ProcessPackages(logger *zap.Logger, packages [][]string, fn ProcessCallback
 			continue
 		}
 
+		// Filter by repository if specified
+		desiredRepository := viper.GetString("GHMPKG_REPOSITORY")
+		if desiredRepository != "" && repository != desiredRepository {
+			logger.Info("Skipping package due to repository filter",
+				zap.String("repository", repository),
+				zap.String("desiredRepository", desiredRepository),
+				zap.String("packageName", packageName))
+			continue
+		}
+
 		if provider == nil || provider.GetPackageType() != packageType {
 			logger.Info("Creating provider", zap.String("packageType", packageType))
 			var err error


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This change allows you to migrate a single repo of packages versus everything at once. This allows sharding, coupled with being able to add this to a post migration workflow for individual repo migrations. Is it better to have one large monolithic process or many small processes? Now we can do both.

Note that the changes do not impact export or sync. 

## Checklist

<!-- - [ ] Issue linked if existing -->
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests

## Additional Context

Add any other context or screenshots about the pull request here.