### PR TITLE
gh-migrate-packages creates another folder in lowercase with the container packages

### DIFF
--- a/internal/providers/common.go
+++ b/internal/providers/common.go
@@ -231,7 +231,7 @@ func (p *BaseProvider) uploadPackage(
 	if packageType == "container" {
 		parts := strings.Split(filename, ":")
 		tag := parts[1]
-		packageDir = filepath.Join(migrationPath, "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, tag)
+		packageDir = filepath.Join(migrationPath, "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, strings.ToLower(packageName), tag)
 	} else {
 		packageDir = filepath.Join(migrationPath, "packages", viper.GetString("GHMPKG_SOURCE_ORGANIZATION"), packageType, packageName, version)
 	}

--- a/internal/providers/container.go
+++ b/internal/providers/container.go
@@ -142,12 +142,13 @@ func (p *ContainerProvider) FetchPackageFiles(logger *zap.Logger, owner, reposit
 
 // Download pulls a container image from the source registry and saves it locally.
 func (p *ContainerProvider) Download(logger *zap.Logger, owner, repository, packageType, packageName, version, filename string) (ResultState, error) {
-	// Normalize names for container images
-	owner, repository, packageName = p.normalizeNames(owner, repository, packageName)
+	// Normalize names for container registry operations (Docker requires lowercase)
+	// but preserve original owner for file path storage
+	_, _, normalizedPackageName := p.normalizeNames(owner, repository, packageName)
 
 	parts := strings.Split(filename, ":")
 	tag := parts[1]
-	downloadedFilename := fmt.Sprintf("%s-%s.tar", packageName, tag)
+	downloadedFilename := fmt.Sprintf("%s-%s.tar", normalizedPackageName, tag)
 
 	return p.downloadPackage(
 		logger, owner, repository, packageType, packageName, version, filename, &downloadedFilename,


### PR DESCRIPTION
<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist

<!-- - [ ] Issue linked if existing -->
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests

## Additional Context
This pull request makes improvements to how container package names are handled, ensuring consistency and compatibility with Docker's requirements. The changes focus on normalizing package names to lowercase for container operations, while preserving the original names for file path storage and rubygems metadata handling. 

**RubyGems enhancements:**

* Added a new `addGitHubRepoMetadata` method to update or insert the `github_repo` metadata field in gemspec files, ensuring gems are correctly linked to their repository in the target organization. This is now called during the `Rename` process.
* Improved the `Rename` method to also update repository URLs and add the `github_repo` metadata, further ensuring correct repository association after migration.
* Enhanced the package upload flow to extract the gemspec from the gem file when missing, modify it as needed, rebuild the gem, and push the rebuilt package. If extraction or build fails, the original gem is pushed as a fallback.
* Improved error reporting during gem extraction by capturing and returning stderr output, making debugging easier.

**Container package name normalization:**

* Updated the `Download` method in `internal/providers/container.go` to use a normalized (lowercase) package name for Docker-related operations, but retain the original owner and repository names for file storage.
* Modified the `uploadPackage` logic in `internal/providers/common.go` to store container packages using a lowercase package name in the file path, ensuring consistency with Docker naming conventions.
* Solves problem when using wsl/ubuntu terminal or using GitHub hosted ubuntu runner. The tool creates another folder in lowercase with the container packages, which in the sync step is not reachable. With the update the container images are stored in the same directory as the other packages. 


**Before:**
<img width="365" height="670" alt="image" src="https://github.com/user-attachments/assets/527c0323-314c-4d4b-8b39-08ac30d31641" />
 
**After:**
<img width="221" height="139" alt="image" src="https://github.com/user-attachments/assets/705604c7-c311-4009-a99a-cf04a4e8f536" />

